### PR TITLE
Send to Wikipedia sitelink with fallbacks via Hub

### DIFF
--- a/Popup/popup.js
+++ b/Popup/popup.js
@@ -679,7 +679,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const resultsWithUrls = data.search.map((entity) => ({
         id: entity.id,
         label: entity.label,
-        fullurl: `https://${language}.wikipedia.org/wiki/${encodeURIComponent(entity.label)}`,
+        fullurl: `https://hub.toolforge.org/${entity.id}?l=${language},auto`,
         description: entity.description,
       }));
 

--- a/Popup/popup.js
+++ b/Popup/popup.js
@@ -623,19 +623,20 @@ document.addEventListener('DOMContentLoaded', function () {
     // }).catch((error) => {
     //   console.log('error', error)
     // });
-    const myHeaders = new Headers();
-    myHeaders.append("Cookie", "GeoIP=GH:AA:Accra:5.55:-0.20:v4; NetworkProbeLimit=0.001; WMF-Last-Access=17-Nov-2024; WMF-Last-Access-Global=17-Nov-2024");
+    
+    // const myHeaders = new Headers();
+    // myHeaders.append("Cookie", "GeoIP=GH:AA:Accra:5.55:-0.20:v4; NetworkProbeLimit=0.001; WMF-Last-Access=17-Nov-2024; WMF-Last-Access-Global=17-Nov-2024");
 
-    const requestOptions = {
-      method: "GET",
-      headers: myHeaders,
-      redirect: "follow"
-    };
+    // const requestOptions = {
+    //   method: "GET",
+    //   headers: myHeaders,
+    //   redirect: "follow"
+    // };
 
-    fetch("https://wikidata.org/w/rest.php/wikibase/v0/entities/items/Q14005/descriptions/en", requestOptions)
-      .then((response) => response.text())
-      .then((result) => console.log(result))
-      .catch((error) => console.error(error));
+    // fetch("https://wikidata.org/w/rest.php/wikibase/v0/entities/items/Q14005/descriptions/en", requestOptions)
+    //   .then((response) => response.text())
+    //   .then((result) => console.log(result))
+    //   .catch((error) => console.error(error));
 
     if (currentWord) {
       fetchEntities(currentWord, selectedLanguage)
@@ -679,7 +680,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const resultsWithUrls = data.search.map((entity) => ({
         id: entity.id,
         label: entity.label,
-        fullurl: `https://hub.toolforge.org/${entity.id}?l=${language},auto`,
+        fullurl: `https://www.wikidata.org/wiki/Special:GoToLinkedPage/${language}wiki/${entity.id}`,
         description: entity.description,
       }));
 


### PR DESCRIPTION
Resolves #5.

> By default, the destination is Wikipedia in the user language, which is guessed from the request `accept-language` header, falling back to English if the language header can't be found or the Wikipedia page doesn't exist in this language. [...] Pass a `lang` parameter (or just `l`) to override the `accept-language` header. Pass several values to set the fallback chain. The value `auto` can be used to represent the value of the `accept-language` header.

&mdash;https://hub.toolforge.org/#destination

> By default, when a destination is not found, you are redirected to the Wikidata entity page.

&mdash;https://hub.toolforge.org/#fallback